### PR TITLE
Logging fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,8 +18,6 @@ client.execute('g.V().drop()', { }, (err, results) => {
   if (err) return console.error(err);
   console.log("Result: %s\n", JSON.stringify(results));
 
-//g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)
-
   console.log('Running Add Vertex1'); 
   client.execute("g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44).property('userid', 1)", { }, (err, results) => {
     if (err) return console.error(err);

--- a/app.js
+++ b/app.js
@@ -16,35 +16,32 @@ const client = Gremlin.createClient(
 console.log('Running Drop');
 client.execute('g.V().drop()', { }, (err, results) => {
   if (err) return console.error(err);
-  console.log(results);
-  console.log();
+  console.log("Result: %s\n", JSON.stringify(results));
 
 //g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39)
 
   console.log('Running Add Vertex1'); 
   client.execute("g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44).property('userid', 1)", { }, (err, results) => {
     if (err) return console.error(err);
-    console.log(JSON.stringify(results));
-    console.log();
+    console.log("Result: %s\n", JSON.stringify(results));
     
     console.log('Running Add Vertex2'); 
     client.execute("g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39).property('userid', 2)", { }, (err, results) => {
       if (err) return console.error(err);
-      console.log(JSON.stringify(results));
-      console.log();
+      console.log("Result: %s\n", JSON.stringify(results));
 
       console.log('Running Add Edge'); 
       client.execute("g.V('thomas').addE('knows').to(g.V('mary'))", { }, (err, results) => {
         if (err) return console.error(err);
-        console.log(JSON.stringify(results));
-        console.log();
+        console.log("Result: %s\n", JSON.stringify(results));
         
         console.log('Running Count'); 
         client.execute("g.V().count()", { }, (err, results) => {
           if (err) return console.error(err);
-          console.log(JSON.stringify(results));
-          console.log();
+          console.log("Result: %s\n", JSON.stringify(results));
+          console.log("Finished");
         });
+
       });
       
     });


### PR DESCRIPTION
Using print format instead of `console.log()` for new lines. Adding a "finished" step.