### PR TITLE
Fix async error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -81,8 +81,11 @@ function countVertices(callback)
 });
 }
 
-function finish(callback)
+function finish(err, result)
 {
+    if (err) {
+        return console.error(err);
+    }
     console.log("Finished");
     console.log('Press any key to exit');
     
@@ -91,14 +94,10 @@ function finish(callback)
     process.stdin.on('data', process.exit.bind(process, 0));
 }
 
-try{
-    async.waterfall([
-        dropGraph,
-        addVertex1,
-        addVertex2,
-        addEdge,
-        countVertices
-    ], finish);
-} catch(err) {
-    console.log(err)
-}
+async.waterfall([
+    dropGraph,
+    addVertex1,
+    addVertex2,
+    addEdge,
+    countVertices
+], finish);

--- a/app.js
+++ b/app.js
@@ -20,7 +20,10 @@ function dropGraph(callback)
 {
     console.log('Running Drop');
     client.execute('g.V().drop()', { }, (err, results) => {
-        if (err) callback(console.error(err));
+        if (err) {
+            return callback(console.error(err));
+        }
+
         console.log("Result: %s\n", JSON.stringify(results));
         callback(null)
     });
@@ -30,9 +33,12 @@ function addVertex1(callback)
 {
     console.log('Running Add Vertex1'); 
     client.execute("g.addV('person').property('id', 'thomas').property('firstName', 'Thomas').property('age', 44).property('userid', 1)", { }, (err, results) => {
-      if (err) callback(console.error(err));
-      console.log("Result: %s\n", JSON.stringify(results));
-      callback(null)
+        if (err) {
+            return callback(console.error(err));
+        }
+
+        console.log("Result: %s\n", JSON.stringify(results));
+        callback(null)
     });
 }
 
@@ -40,9 +46,12 @@ function addVertex2(callback)
 {
     console.log('Running Add Vertex2'); 
     client.execute("g.addV('person').property('id', 'mary').property('firstName', 'Mary').property('lastName', 'Andersen').property('age', 39).property('userid', 2)", { }, (err, results) => {
-      if (err) calback(console.error(err));
-      console.log("Result: %s\n", JSON.stringify(results));
-      callback(null)
+        if (err) {
+            return calback(console.error(err));
+        }
+
+        console.log("Result: %s\n", JSON.stringify(results));
+        callback(null)
     });
 }
 
@@ -50,20 +59,26 @@ function addEdge(callback)
 {
     console.log('Running Add Edge'); 
     client.execute("g.V('thomas').addE('knows').to(g.V('mary'))", { }, (err, results) => {
-      if (err) callback(console.error(err));
-      console.log("Result: %s\n", JSON.stringify(results));
-      callback(null)
+        if (err) {
+            return callback(console.error(err));
+        }
+
+        console.log("Result: %s\n", JSON.stringify(results));
+        callback(null)
     });
 }
 
 function countVertices(callback)
 {
-    console.log('Running Count'); 
+    console.log('Running Count');
     client.execute("g.V().count()", { }, (err, results) => {
-      if (err) callback(console.error(err));
-      console.log("Result: %s\n", JSON.stringify(results));
-      callback(null)
-    });
+    if (err) {
+        return callback(console.error(err));
+    }
+
+    console.log("Result: %s\n", JSON.stringify(results));
+    callback(null)
+});
 }
 
 function finish(callback)


### PR DESCRIPTION
This pull request ensures that callbacks are not called twice with an `undefined` value after handling a potential error.
It also fixes the way error/results are being handled by `async.waterfall`.

I recommend that you checkout the branch first and ensure everything is working properly since I couldn't test it on my machine.