### PR TITLE
Update README.md and config.js to be more accessible to beginners

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Azure Cosmos DB is a globally distributed multi-model database. One of the suppo
 
 * Then, clone this repository using `git clone https://github.com/Azure-Samples/azure-cosmos-db-graph-nodejs-getting-started.git`
 
-* Next, substitute the graph endpoint (`*.graphs.azure.com`), your database and collection (graph) values, and primary master key in `config.js` with your Cosmos DB account's values. 
+* Next, substitute the graph endpoint (`*.gremlin.cosmosdb.azure.com`), your database and collection (graph) values, and primary master key in `config.js` with your Cosmos DB account's values. 
 
 * From a command prompt or shell, run `npm install` from the root directory to install the gremlin-javascript and async modules, and their dependencies.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Azure Cosmos DB is a globally distributed multi-model database. One of the suppo
 
 * Then, clone this repository using `git clone https://github.com/Azure-Samples/azure-cosmos-db-graph-nodejs-getting-started.git`
 
-* Next, substitute the graph endpoint (`*.gremlin.cosmosdb.azure.com`), your database and collection (graph) values, and primary master key in `config.js` with your Cosmos DB account's values. 
+* Next, substitute the Gremlin endpoint (`*.gremlin.cosmosdb.azure.com`), your database and collection (graph) values, and primary master key in `config.js` with your Cosmos DB account's values. 
 
 * From a command prompt or shell, run `npm install` from the root directory to install the gremlin-javascript and async modules, and their dependencies.
 

--- a/config.js
+++ b/config.js
@@ -1,8 +1,8 @@
 var config = {}
 
-config.endpoint = "GRAPHENDPOINT.gremlin.cosmosdb.azure.com";
-config.primaryKey = "PRIMARYKEY";
-config.database = "graphdb"
-config.collection = "graphcoll"
+config.endpoint = "{cosmosdbacct}.gremlin.cosmosdb.azure.com";
+config.primaryKey = "{primarykey}";
+config.database = "{databasename}"
+config.collection = "{collectionname}"
 
 module.exports = config;


### PR DESCRIPTION
In my experience getting started with this example, the example endpoint format `*.graphs.azure.com` led to some uncertainty. The endpoints I saw were of the formats `*.gremlin.cosmosdb.azure.com` and `*.documents.azure.com`. The gremlin endpoint worked for me. 

While updating that example endpoint format, I considered that making similar changes for consistency in config.js might help new users recognize more quickly what they would need to change.